### PR TITLE
Move react dependency to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
   },
   "dependencies": {
     "commonmark": "^0.19.0",
-    "commonmark-react-renderer": "^1.0.2",
-    "react": "^0.13.3"
+    "commonmark-react-renderer": "^1.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=0.13.3"
   }
 }


### PR DESCRIPTION
In order to maintain compatibility with projects using react v0.14.0, we want to use the react version installed on the owner's project. This also prevents a separate version of react being packaged with react-markdown.