### PR TITLE
Add `props` object to allow props on container element such as `id` and `htmlFor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ If you either set `escapeHtml` or `skipHtml` to `true`, this component does not 
 
 * `source` - *string* The Markdown source to parse (**required**)
 * `className` - *string* Class name of the container element (default: `''`).
-* `props` - *object* An object containing custom element props to put on the container element such as `id` and `htmlFor`.
 * `containerTagName` - *string* Tag name for the container element, since Markdown can have many root-level elements, the component need to wrap them in something (default: `div`).
+* `containerProps` - *object* An object containing custom element props to put on the container element such as `id` and `htmlFor`.
 * `escapeHtml` - *boolean* Setting to `true` will escape HTML blocks, rendering plain text instead of inserting the blocks as raw HTML (default: `false`).
 * `skipHtml` - *boolean* Setting to `true` will skip inlined and blocks of HTML (default: `false`).
 * `sourcePos` - *boolean* Setting to `true` will add `data-sourcepos` attributes to all elements, indicating where in the markdown source they were rendered from (default: `false`).

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If you either set `escapeHtml` or `skipHtml` to `true`, this component does not 
 
 * `source` - *string* The Markdown source to parse (**required**)
 * `className` - *string* Class name of the container element (default: `''`).
+* `props` - *object* An object containing custom element props to put on the container element such as `id` and `htmlFor`.
 * `containerTagName` - *string* Tag name for the container element, since Markdown can have many root-level elements, the component need to wrap them in something (default: `div`).
 * `escapeHtml` - *boolean* Setting to `true` will escape HTML blocks, rendering plain text instead of inserting the blocks as raw HTML (default: `false`).
 * `skipHtml` - *boolean* Setting to `true` will skip inlined and blocks of HTML (default: `false`).

--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -12,7 +12,7 @@ var ReactMarkdown = React.createClass({
 
     propTypes: {
         className: propTypes.string,
-        props: propTypes.object,
+        containerProps: propTypes.object,
         source: propTypes.string.isRequired,
         containerTagName: propTypes.string,
         sourcePos: propTypes.bool,
@@ -35,7 +35,7 @@ var ReactMarkdown = React.createClass({
     },
 
     render: function() {
-        var containerProps = this.props.props || {};
+        var containerProps = this.props.containerProps || {};
         var renderer = new ReactRenderer(this.props);
         var ast = parser.parse(this.props.source || '');
 

--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -12,6 +12,7 @@ var ReactMarkdown = React.createClass({
 
     propTypes: {
         className: propTypes.string,
+        props: propTypes.object,
         source: propTypes.string.isRequired,
         containerTagName: propTypes.string,
         sourcePos: propTypes.bool,
@@ -34,7 +35,7 @@ var ReactMarkdown = React.createClass({
     },
 
     render: function() {
-        var containerProps = {};
+        var containerProps = this.props.props || {};
         var renderer = new ReactRenderer(this.props);
         var ast = parser.parse(this.props.source || '');
 

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -38,7 +38,7 @@ describe('ReactMarkdown', function() {
         var rendered = TestUtils.renderIntoDocument(
             React.createElement(ReactMarkdown, {
                 source: testMarkdown,
-                props: {
+                containerProps: {
                     htmlFor: 'myElementID'
                 }
             })
@@ -51,7 +51,7 @@ describe('ReactMarkdown', function() {
         var rendered = TestUtils.renderIntoDocument(
             React.createElement(ReactMarkdown, {
                 source: testMarkdown,
-                props: {
+                containerProps: {
                     id: 'myElementID'
                 }
             })

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -34,6 +34,32 @@ describe('ReactMarkdown', function() {
         expect(ReactDom.findDOMNode(rendered).getAttribute('class')).to.equal('foo bar');
     });
 
+    it('should set custom prop htmlFor on the container if props are passed as prop', function() {
+        var rendered = TestUtils.renderIntoDocument(
+            React.createElement(ReactMarkdown, {
+                source: testMarkdown,
+                props: {
+                    htmlFor: 'myElementID'
+                }
+            })
+        );
+
+        expect(ReactDom.findDOMNode(rendered).getAttribute('for')).to.equal('myElementID');
+    });
+
+    it('should set custom prop ID on the container if props are passed as prop', function() {
+        var rendered = TestUtils.renderIntoDocument(
+            React.createElement(ReactMarkdown, {
+                source: testMarkdown,
+                props: {
+                    id: 'myElementID'
+                }
+            })
+        );
+
+        expect(ReactDom.findDOMNode(rendered).getAttribute('id')).to.equal('myElementID');
+    });
+
     it('should have rendered a div with the right children', function() {
         var rendered = TestUtils.renderIntoDocument(
             React.createElement(ReactMarkdown, { source: testMarkdown })


### PR DESCRIPTION
I ran into issues when making a `label` element that was rendered using `ReactMarkdown`, not being able to add, eg., the `htmlFor` prop.

This pull request enables a `props` prop object on the `ReactMarkdown` component.

```
<ReactMarkdown containerTagName="label" props={{htmlFor: "myElementID"}} source="This is my **label**" />
``` 