### PR TITLE
Add `childBefore` and `childAfter` props

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you either set `escapeHtml` or `skipHtml` to `true`, this component does not 
   * `type` - *string* The type of node - same ones accepted in `allowedTypes` and `disallowedTypes`
   * `renderer` - *string* The resolved renderer for this node
   * `props` - *object* Properties for this node
-  * `children* - *array* Array of children
+  * `children` - *array* Array of children
 * `renderers` - *object* An object where the keys represent the node type and the value is a React component. The object is merged with the default renderers. The props passed to the component varies based on the type of node. See the [type renderer options](https://github.com/rexxars/commonmark-react-renderer#type-renderer-options) of `commonmark-react-renderer` for more details.
 * `transformLinkUri` - *function|null* Function that gets called for each encountered link with a single argument - `uri`. The returned value is used in place of the original. The default link URI transformer acts as an XSS-filter, neutralizing things like `javascript:`, `vbscript:` and `file:` protocols. If you specify a custom function, this default filter won't be called, but you can access it as `require('react-markdown').uriTransformer`. If you want to disable the default transformer, pass `null` to this option.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ If you either set `escapeHtml` or `skipHtml` to `true`, this component does not 
 * `className` - *string* Class name of the container element (default: `''`).
 * `containerTagName` - *string* Tag name for the container element, since Markdown can have many root-level elements, the component need to wrap them in something (default: `div`).
 * `containerProps` - *object* An object containing custom element props to put on the container element such as `id` and `htmlFor`.
+* `childBefore` - *object* A single child object that is rendered **before** the markdown source but within the container element
+* `childAfter` - *object* A single child object that is rendered **after** the markdown source but within the container element
 * `escapeHtml` - *boolean* Setting to `true` will escape HTML blocks, rendering plain text instead of inserting the blocks as raw HTML (default: `false`).
 * `skipHtml` - *boolean* Setting to `true` will skip inlined and blocks of HTML (default: `false`).
 * `sourcePos` - *boolean* Setting to `true` will add `data-sourcepos` attributes to all elements, indicating where in the markdown source they were rendered from (default: `false`).

--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -15,6 +15,8 @@ var ReactMarkdown = React.createClass({
         containerProps: propTypes.object,
         source: propTypes.string.isRequired,
         containerTagName: propTypes.string,
+        childBefore: propTypes.object,
+        childAfter: propTypes.object,
         sourcePos: propTypes.bool,
         escapeHtml: propTypes.bool,
         skipHtml: propTypes.bool,
@@ -53,8 +55,10 @@ var ReactMarkdown = React.createClass({
         }
 
         return React.createElement.apply(React,
-            [this.props.containerTagName, containerProps]
-                .concat(renderer.render(ast))
+            [this.props.containerTagName, containerProps, this.props.childBefore]
+                .concat(renderer.render(ast).concat(
+                    [this.props.childAfter]
+                ))
         );
     }
 });

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -47,6 +47,22 @@ describe('ReactMarkdown', function() {
         expect(ReactDom.findDOMNode(rendered).getAttribute('for')).to.equal('myElementID');
     });
 
+    it('should render before and after children if passed as props', function() {
+        var beforeText = 'Hello again';
+        var afterText = 'friend of a friend';
+
+        var rendered = TestUtils.renderIntoDocument(
+            React.createElement(ReactMarkdown, {
+                source: testMarkdown,
+                childBefore: React.createElement('ul', null, beforeText),
+                childAfter: React.createElement('a', null, afterText)
+            })
+        );
+
+        expect(ReactDom.findDOMNode(rendered).firstChild.innerHTML).to.equal(beforeText);
+        expect(ReactDom.findDOMNode(rendered).lastChild.innerHTML).to.equal(afterText);
+    });
+
     it('should set custom prop ID on the container if props are passed as prop', function() {
         var rendered = TestUtils.renderIntoDocument(
             React.createElement(ReactMarkdown, {


### PR DESCRIPTION
In some cases, I'd find it useful to render children *before* and/or *after* the rendered markdown, yet *within the same container element*.

**Simple pseudo example:**
```
var childBefore = (<img src="avatar.png" alt="User avatar" />);
<ReactMarkdown source="**Hello**" containerTagName="div" childBefore={childBefore} />
```
```
<div>
   <img src="avatar.png" alt="User avatar" />
   <strong>Hello</strong>
</div>
```