### PR TITLE
Pass the walker to the walker callback function

### DIFF
--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -46,7 +46,7 @@ var ReactMarkdown = React.createClass({
             var event;
 
             while ((event = walker.next())) {
-                this.props.walker.call(this, event);
+                this.props.walker.call(this, event, walker);
             }
         }
 


### PR DESCRIPTION
This comes in handy when you need to do destructive updates for the AST and have to call `walker.resumeAt` afterwards.  