### PR TITLE
BugFix: Type interpretation has broken

### DIFF
--- a/react-markdown.d.ts
+++ b/react-markdown.d.ts
@@ -1,52 +1,59 @@
 // Type definitions for react-markdown v2.2.2
 // Project: https://github.com/rexxars/react-markdown
-// Definitions by: Ruslan Ibragimov <https://github.com/IRus>
+// Definitions by: Ruslan Ibragimov <https://github.com/IRus>, Kohei Asai <me@axross.io>
 
-import {Component, ReactNode} from 'react';
+import { Component, ReactElement, ReactNode } from 'react';
 
-declare namespace __ReactMarkdown {
+declare class ReactMarkdown extends Component<ReactMarkdown.ReactMarkdownProps, {}> {}
 
-    interface AllowNode {
-        readonly type: string;
-        readonly renderer: string;
-        readonly props: any;
-        readonly children: ReactNode[];
-    }
+declare namespace ReactMarkdown {
+  interface AllowNode {
+    readonly type: string;
+    readonly renderer: string;
+    readonly props: any;
+    readonly children: ReactNode[];
+  }
 
-    interface WalkerNode {
-        readonly entering: boolean,
-        readonly node: { type: string }
-    }
+  interface WalkerNode {
+    readonly entering: boolean,
+    readonly node: { type: string }
+  }
 
-    interface NodeWalker {
-        next: () => WalkerNode;
-    }
+  interface NodeWalker {
+    next: () => WalkerNode;
+  }
 
-    type NodeType = 'HtmlInline' | 'HtmlBlock' | 'Text' | 'Paragraph' | 'Heading' | 'Softbreak' | 'Hardbreak' | 'Link' | 'Image' | 'Emph' | 'Code' | 'CodeBlock' | 'BlockQuote' | 'List' | 'Item' | 'Strong' | 'ThematicBreak';
+  export type NodeType = 'HtmlInline' | 'HtmlBlock' | 'Text' | 'Paragraph' | 'Heading' | 'Softbreak' | 'Hardbreak' | 'Link' | 'Image' | 'Emph' | 'Code' | 'CodeBlock' | 'BlockQuote' | 'List' | 'Item' | 'Strong' | 'ThematicBreak';
 
-    export interface ReactMarkdownProps {
-        readonly className?: string;
-        readonly containerProps?: any;
-        readonly source: string;
-        readonly containerTagName?: string;
-        readonly childBefore?: any;
-        readonly childAfter?: any;
-        readonly sourcePos?: boolean;
-        readonly escapeHtml?: boolean;
-        readonly skipHtml?: boolean;
-        readonly softBreak?: string;
-        readonly allowNode?: (node: AllowNode) => boolean;
-        readonly allowedTypes?: NodeType[];
-        readonly disallowedTypes?: NodeType[];
-        readonly transformLinkUri?: (uri: string) => string;
-        readonly transformImageUri?: (uri: string) => string;
-        readonly unwrapDisallowed?: boolean;
-        readonly renderers?: {[nodeType: string]: Component<any, any>};
-        readonly walker?: NodeWalker;
-    }
+  export interface ReactMarkdownProps {
+    readonly className?: string;
+    readonly containerProps?: any;
+    readonly source: string;
+    readonly containerTagName?: string;
+    readonly childBefore?: any;
+    readonly childAfter?: any;
+    readonly sourcePos?: boolean;
+    readonly escapeHtml?: boolean;
+    readonly skipHtml?: boolean;
+    readonly softBreak?: string;
+    readonly allowNode?: (node: AllowNode) => boolean;
+    readonly allowedTypes?: NodeType[];
+    readonly disallowedTypes?: NodeType[];
+    readonly transformLinkUri?: (uri: string) => string;
+    readonly transformImageUri?: (uri: string) => string;
+    readonly unwrapDisallowed?: boolean;
+    readonly renderers?: {[nodeType: string]: Component<any, any>};
+    readonly walker?: NodeWalker;
+  }
 
-    export default class ReactMarkdown extends Component<ReactMarkdownProps, {}> {
-    }
+  type Renderer<T> = (props: T) => ReactElement<T>;
+  interface Renderers {
+    [key: string]: string | Renderer<any>;
+  }
+
+  export var types: NodeType[];
+  export var renderers: Renderers;
+  export var uriTransformer: (uri: string) => string;
 }
 
-export = __ReactMarkdown;
+export = ReactMarkdown;

--- a/test/react-markdown-test.tsx
+++ b/test/react-markdown-test.tsx
@@ -1,15 +1,12 @@
-/// <reference path="../react-markdown.d.ts" />
-
-import ReactMarkdown, {NodeType} from 'react-markdown';
+import * as ReactMarkdown from '../';
 
 const text = "# Hello";
 
 const ex1: JSX.Element = (
-    <ReactMarkdown source={text}/>
+    <ReactMarkdown source={text} />
 );
 
-
-const allowedTypes: NodeType[] = ['BlockQuote', 'Code'];
+const allowedTypes: ReactMarkdown.NodeType[] = ['BlockQuote', 'Code'];
 
 const ex2: JSX.Element = (
     <ReactMarkdown


### PR DESCRIPTION
`react-markdown` do not work with TypeScript using default configuration.
I fix it. Please check and merge this.