### PR TITLE
Update Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you are using Webpack, you need to enable a JSON-loader. To do so, first `npm
     module: {
         loaders: [{
             test: /\.json$/,
-            loader: 'json'
+            loader: 'json-loader'
         }]
     }
 }


### PR DESCRIPTION
- fixing "It's no longer allowed to omit the '-loader' suffix when using loaders"