### PR TITLE
Remove `React.createClass`

### DIFF
--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -6,65 +6,66 @@ var ReactRenderer = require('commonmark-react-renderer');
 
 var propTypes = React.PropTypes;
 
-var ReactMarkdown = React.createClass({
-    displayName: 'ReactMarkdown',
+function ReactMarkdown(props) {
+    React.Component.call(this, props);
+}
 
-    propTypes: {
-        className: propTypes.string,
-        containerProps: propTypes.object,
-        source: propTypes.string.isRequired,
-        containerTagName: propTypes.string,
-        childBefore: propTypes.object,
-        childAfter: propTypes.object,
-        sourcePos: propTypes.bool,
-        escapeHtml: propTypes.bool,
-        skipHtml: propTypes.bool,
-        softBreak: propTypes.string,
-        allowNode: propTypes.func,
-        allowedTypes: propTypes.array,
-        disallowedTypes: propTypes.array,
-        transformLinkUri: propTypes.func,
-        transformImageUri: propTypes.func,
-        unwrapDisallowed: propTypes.bool,
-        renderers: propTypes.object,
-        walker: propTypes.func,
-        parserOptions: propTypes.object
-    },
+ReactMarkdown.prototype = Object.create(React.Component.prototype);
+ReactMarkdown.prototype.constructor = ReactMarkdown;
 
-    getDefaultProps: function() {
-        return {
-            containerTagName: 'div',
-            parserOptions: {}
-        };
-    },
+ReactMarkdown.prototype.render = function() {
+    var containerProps = this.props.containerProps || {};
+    var renderer = new ReactRenderer(this.props);
+    var parser = new Parser(this.props.parserOptions);
+    var ast = parser.parse(this.props.source || '');
 
-    render: function() {
-        var containerProps = this.props.containerProps || {};
-        var renderer = new ReactRenderer(this.props);
-        var parser = new Parser(this.props.parserOptions);
-        var ast = parser.parse(this.props.source || '');
+    if (this.props.walker) {
+        var walker = ast.walker();
+        var event;
 
-        if (this.props.walker) {
-            var walker = ast.walker();
-            var event;
-
-            while ((event = walker.next())) {
-                this.props.walker.call(this, event, walker);
-            }
+        while ((event = walker.next())) {
+            this.props.walker.call(this, event, walker);
         }
-
-        if (this.props.className) {
-            containerProps.className = this.props.className;
-        }
-
-        return React.createElement.apply(React,
-            [this.props.containerTagName, containerProps, this.props.childBefore]
-                .concat(renderer.render(ast).concat(
-                    [this.props.childAfter]
-                ))
-        );
     }
-});
+
+    if (this.props.className) {
+        containerProps.className = this.props.className;
+    }
+
+    return React.createElement.apply(React,
+        [this.props.containerTagName, containerProps, this.props.childBefore]
+            .concat(renderer.render(ast).concat(
+                [this.props.childAfter]
+            ))
+    );
+};
+
+ReactMarkdown.propTypes = {
+    className: propTypes.string,
+    containerProps: propTypes.object,
+    source: propTypes.string.isRequired,
+    containerTagName: propTypes.string,
+    childBefore: propTypes.object,
+    childAfter: propTypes.object,
+    sourcePos: propTypes.bool,
+    escapeHtml: propTypes.bool,
+    skipHtml: propTypes.bool,
+    softBreak: propTypes.string,
+    allowNode: propTypes.func,
+    allowedTypes: propTypes.array,
+    disallowedTypes: propTypes.array,
+    transformLinkUri: propTypes.func,
+    transformImageUri: propTypes.func,
+    unwrapDisallowed: propTypes.bool,
+    renderers: propTypes.object,
+    walker: propTypes.func,
+    parserOptions: propTypes.object
+};
+
+ReactMarkdown.defaultProps = {
+    containerTagName: 'div',
+    parserOptions: {}
+};
 
 ReactMarkdown.types = ReactRenderer.types;
 ReactMarkdown.renderers = ReactRenderer.renderers;


### PR DESCRIPTION
Hi! :wave: Thanks for creating this component!

The `React.createClass` method is going to be deprecated soon and will
be removed in React v16.
https://github.com/facebook/react/pull/9232
    
This patch changes the component to a class extended from
`React.Component`. It does it manually by assigning to the prototype,
to avoid introducing a compile step.

e; Oops, goofed up the title there with `hub pull-request` :sweat_smile: 