### PR TITLE
Allow passing components to containerTagName

### DIFF
--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -43,7 +43,7 @@ ReactMarkdown.propTypes = {
     className: propTypes.string,
     containerProps: propTypes.object,
     source: propTypes.string.isRequired,
-    containerTagName: propTypes.string,
+    containerTagName: propTypes.oneOfType([propTypes.string, propTypes.func]),
     childBefore: propTypes.object,
     childAfter: propTypes.object,
     sourcePos: propTypes.bool,


### PR DESCRIPTION
While this kinda defeats the naming of `containerTagName`, it _does_ allow me to use this library completely unmodified in React Native! 

I'm building custom renderers for each output type, and I just used this to remove the last reference to a DOM element.

Passing a component to this prop works today, so I'm just updating the PropTypes declaration.

Have a great day!