### PR TITLE
transformLinkUri - provide all available arguments

### DIFF
--- a/react-markdown.d.ts
+++ b/react-markdown.d.ts
@@ -62,8 +62,8 @@ declare namespace ReactMarkdown {
     readonly allowNode?: (node: AllowNode, number: index, parent) => boolean
     readonly allowedTypes?: NodeType[]
     readonly disallowedTypes?: NodeType[]
-    readonly transformLinkUri?: (uri: string) => string
-    readonly transformImageUri?: (uri: string) => string
+    readonly transformLinkUri?: (uri: string, children?: ReactNode, title?: string) => string
+    readonly transformImageUri?: (uri: string, children?: ReactNode, title?: string, alt?: string) => string
     readonly unwrapDisallowed?: boolean
     readonly renderers?: {[nodeType: string]: ReactType}
   }

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -76,14 +76,14 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
     case 'link':
       assignDefined(props, {
         title: node.title || undefined,
-        href: opts.transformLinkUri ? opts.transformLinkUri(node.url) : node.url
+        href: opts.transformLinkUri ? opts.transformLinkUri(node.url, node.children, node.title) : node.url
       })
       break
     case 'image':
       assignDefined(props, {
         alt: node.alt || undefined,
         title: node.title || undefined,
-        src: opts.transformImageUri ? opts.transformImageUri(node.url) : node.url
+        src: opts.transformImageUri ? opts.transformImageUri(node.url, node.children, node.title, node.alt) : node.url
       })
       break
     case 'linkReference':


### PR DESCRIPTION
Currently `transformLinkUri` can be provided for custom URL transformations, but not all available arguments are passed.
This makes it impossible to provide custom URL transformation logic, based on the URL title and content.

With this change both children and title are provided to the `transformLinkUri` (without changing the default `uriTransformer` implementation
