### PR TITLE
enable transformImageUri also for image references, not only direct images

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -96,7 +96,7 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
       break
     case 'imageReference':
       assignDefined(props, {
-        src: ref.href,
+        src: opts.transformImageUri ? opts.transformImageUri(ref.href, node.children, ref.title, node.alt) : ref.href,
         title: ref.title || undefined,
         alt: node.alt || undefined
       })


### PR DESCRIPTION
currently, the transform function is not yet applied for referenced images