### PR TITLE
Pass the React Key into an overridden text renderer and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ this has been planned, but if you're feeling up to the task, create an issue and
 * `renderers` - _object_ An object where the keys represent the node type and the value is a React
   component. The object is merged with the default renderers. The props passed to the component
   varies based on the type of node.
+  * With one exception: if the key is `text`, the value should be a function that takes the literal text and returns a new string or React element.
 
 ## Node types
 

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -6,16 +6,17 @@ const xtend = require('xtend')
 function astToReact(node, options, parent = {}, index = 0) {
   const renderer = options.renderers[node.type]
 
-	if (node.type === 'text') {
-    return renderer ? renderer(node.value) : node.value
+  const pos = node.position.start
+  const key = [node.type, pos.line, pos.column].join('-')
+
+  if (node.type === 'text') {
+    return renderer ? renderer(node.value, key) : node.value
   }
 
   if (typeof renderer !== 'function' && typeof renderer !== 'string') {
     throw new Error(`Renderer for type \`${node.type}\` not defined or is not renderable`)
   }
 
-  const pos = node.position.start
-  const key = [node.type, pos.line, pos.column].join('-')
   const nodeProps = getNodeProps(node, key, options, renderer, parent, index)
 
   return React.createElement(

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -502,3 +502,13 @@ test('should be able to override text renderer', () => {
   const component = renderer.create(<Markdown source={input} renderers={{text: textRenderer}} />)
   expect(component.toJSON()).toMatchSnapshot()
 })
+
+test('should pass the key to an overriden text renderer', () => {
+  const textRenderer = (text, key) => {
+    expect(key).toEqual('text-1-1');
+    return <marquee key={key}>{text}</marquee>;
+  }
+
+  renderer.create(<Markdown source={'foo'} renderers={{ text: textRenderer }} />)
+})
+


### PR DESCRIPTION
## Commit 1
If you override the text renderer with a function that returns a React Element, you'll get a "unique key error" warning if you don't pass in a key.

This commit passes the key that `astToReact` gives to every other node to the text renderer function. If you are simply returning a string from your renderer function, you can just ignore the extra parameter.

Note: another way to fix this would be to have the text renderer accept a React Component like the rest of the renderers. That would be a breaking change at this point though.

## Commit 2
The current README docs are slightly wrong.

When you override the `text` renderer it expects a function, but the docs imply that it always takes a React Component. If you pass it a React Component you will get an error.

This PR lets users know that they should pass in a function instead.