### PR TITLE
Add support for fragment renderers

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -13,7 +13,7 @@ function astToReact(node, options, parent = {}, index = 0) {
     return renderer ? renderer(node.value, key) : node.value
   }
 
-  if (typeof renderer !== 'function' && typeof renderer !== 'string') {
+  if (typeof renderer !== 'function' && typeof renderer !== 'string' && !isReactFragment(renderer)) {
     throw new Error(`Renderer for type \`${node.type}\` not defined or is not renderable`)
   }
 
@@ -33,6 +33,10 @@ function astToReact(node, options, parent = {}, index = 0) {
       )
     )
   }
+}
+
+function isReactFragment(renderer) {
+  return React.Fragment && React.Fragment === renderer;
 }
 
 // eslint-disable-next-line max-params, complexity

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -658,9 +658,6 @@ Array [
   <p>
     foo
   </p>,
-  <span>
-    And that is the end of that
-  </span>,
 ]
 `;
 

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -416,13 +416,7 @@ test('should throw on invalid renderer', () => {
 
 test('should be able to override root renderer with fragment renderer', () => {
   const input = '# Header\n\nfoo'
-  const root = props => (
-    <React.Fragment>
-      {props.children}
-      <span>And that is the end of that</span>
-    </React.Fragment>
-  )
-
+  const root = React.Fragment
   const component = renderer.create(<Markdown source={input} renderers={{root}} />)
   expect(component.toJSON()).toMatchSnapshot()
 })


### PR DESCRIPTION
This PR updatest `astToReact` so that it supports passing `React.Fragment` as a renderer without wrapping it in a function.