### PR TITLE
Update TypeScript definition and prop types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-markdown v3.0.0-rc1
+// Type definitions for react-markdown > v3.3.0
 // Project: https://github.com/rexxars/react-markdown
 // Definitions by: Ruslan Ibragimov <https://github.com/IRus>, Kohei Asai <me@axross.io>
 
@@ -7,23 +7,16 @@ import {Component, ReactElement, ReactNode, ReactType} from 'react'
 declare class ReactMarkdown extends Component<ReactMarkdown.ReactMarkdownProps, {}> {}
 
 declare namespace ReactMarkdown {
-  interface AllowNode {
-    readonly type: string
-    readonly value?: string
-    readonly depth?: number
-    readonly children?: ReactNode[]
-  }
-
-  interface SourcePosition {
+  interface Point {
     readonly line: number
     readonly column: number
-    readonly offset: number
+    readonly offset?: number
   }
 
-  interface NodePosition {
-    readonly start: SourcePosition
-    readonly end: SourcePosition
-    readonly indent: number[]
+  interface Position {
+    readonly start: Point
+    readonly end: Point
+    readonly indent?: number[]
   }
 
   export type NodeType =
@@ -54,25 +47,66 @@ declare namespace ReactMarkdown {
     | 'html'
     | 'virtualHtml'
 
+  export type AlignType =
+    | "left"
+    | "right"
+    | "center"
+    | null
+
+  export type ReferenceType =
+    | "shortcut"
+    | "collapsed"
+    | "full"
+
   export interface ReactMarkdownProps {
     readonly className?: string
     readonly source: string
     readonly sourcePos?: boolean
     readonly escapeHtml?: boolean
     readonly skipHtml?: boolean
-    readonly allowNode?: (node: AllowNode, index: number, parent: NodeType) => boolean
+    readonly allowNode?: (node: MarkdownAbstractSyntaxTree, index: number, parent: NodeType) => boolean
     readonly allowedTypes?: NodeType[]
     readonly disallowedTypes?: NodeType[]
     readonly transformLinkUri?: (uri: string, children?: ReactNode, title?: string) => string
     readonly transformImageUri?: (uri: string, children?: ReactNode, title?: string, alt?: string) => string
     readonly unwrapDisallowed?: boolean
     readonly renderers?: {[nodeType: string]: ReactType}
+    readonly astPlugins?: MdastPlugin[]
+    readonly plugins?: any[] | (() => void)
+  }
+
+  interface RenderProps extends ReactMarkdownProps {
+    readonly definitions?: object
   }
 
   type Renderer<T> = (props: T) => ReactElement<T>
   interface Renderers {
     [key: string]: string | Renderer<any>
   }
+
+  interface MarkdownAbstractSyntaxTree {
+    align?: AlignType[]
+    alt?: string | null
+    checked?: boolean | null
+    children?: MarkdownAbstractSyntaxTree[]
+    data?: {[key: string]: any}
+    depth?: number
+    height?: number
+    identifier?: string
+    lang?: string | null
+    loose?: boolean
+    ordered?: boolean
+    position?: Position
+    referenceType?: ReferenceType
+    start?: number | null
+    title?: string | null
+    type: string
+    url?: string
+    value?: string
+    width?: number
+  }
+
+  type MdastPlugin = (node: MarkdownAbstractSyntaxTree, renderProps?: RenderProps) => MarkdownAbstractSyntaxTree
 
   export var types: NodeType[]
   export var renderers: Renderers

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -66,7 +66,7 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
       props.checked = node.checked
       props.tight = !node.loose
       props.children = (props.tight ? unwrapParagraphs(node) : node.children).map((childNode, i) => {
-        return astToReact(childNode, opts, { node: node, props: props }, i)
+        return astToReact(childNode, opts, {node: node, props: props}, i)
       })
       break
     case 'definition':

--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -39,7 +39,7 @@ const ReactMarkdown = function ReactMarkdown(props) {
 }
 
 function applyParserPlugin(parser, plugin) {
-  return Array.isArray(plugin) ? parser.use(plugin[0], plugin[1]) : parser.use(plugin)
+  return Array.isArray(plugin) ? parser.use(...plugin) : parser.use(plugin)
 }
 
 function determineAstPlugins(props) {
@@ -73,7 +73,9 @@ ReactMarkdown.defaultProps = {
   renderers: {},
   escapeHtml: true,
   skipHtml: false,
-  transformLinkUri: uriTransformer
+  transformLinkUri: uriTransformer,
+  astPlugins: [],
+  plugins: []
 }
 
 ReactMarkdown.propTypes = {
@@ -90,7 +92,8 @@ ReactMarkdown.propTypes = {
   transformImageUri: PropTypes.func,
   astPlugins: PropTypes.arrayOf(PropTypes.func),
   unwrapDisallowed: PropTypes.bool,
-  renderers: PropTypes.object
+  renderers: PropTypes.object,
+  plugins: PropTypes.array
 }
 
 ReactMarkdown.types = allTypes


### PR DESCRIPTION
1. Match the unified API use `unified().use(params1).use(params2)...` with `plugins: [ [ params1 ], [ params2 ], ... ]`
2. Support for `remark-iframes` options. Example usage: `plugins: [ remarkIframes, { 'www.youtube.com': {...} } ]`
3. Update TypeScript definition.