### PR TITLE
Pass node properties to renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
     "remark-breaks": "^1.0.0",
+    "remark-shortcodes": "^0.1.5",
     "rimraf": "^2.6.2",
     "webpack": "^4.1.0",
     "webpack-cli": "^2.0.10"

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -135,6 +135,14 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
       props.skipHtml = opts.skipHtml
       break
     default:
+      assignDefined(
+        props,
+        xtend(node, {
+          type: undefined,
+          position: undefined,
+          children: undefined,
+        }),
+      )
   }
 
   if (typeof renderer !== 'string' && node.value) {

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -6,6 +6,7 @@ const React = require('react')
 const breaks = require('remark-breaks')
 const ReactDom = require('react-dom/server')
 const renderer = require('react-test-renderer')
+const shortcodes = require('remark-shortcodes')
 const Markdown = require('../src/react-markdown')
 
 const render = input => renderer.create(<Markdown source={input} />).toJSON().children
@@ -432,6 +433,18 @@ test('can render the whole spectrum of markdown within a single run', done => {
     expect(component.toJSON()).toMatchSnapshot()
     done()
   })
+})
+
+test('passes along all props when the node type is unknown', () => {
+  expect.assertions(2)
+  const input = 'Text with [[ foo | bar="baz" ]] in the middle'
+  const component = <Markdown source={input} plugins={[shortcodes]} renderers={{ shortcode: ShortcodeRenderer }} escapeHtml={false} />
+
+  const ShortcodeRenderer = props => {
+    expect(props.identifier).toBe('foo')
+    expect(props.attributes).toEqual({ bar: 'baz' })
+    return null
+  }
 })
 
 test('can match and reactify cheap/simple inline html', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5385,6 +5385,10 @@ remark-parse@^5.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
+remark-shortcodes@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/remark-shortcodes/-/remark-shortcodes-0.1.5.tgz#0d8e1c6fbdf89fd9e99347eeb5b73f60e6288870"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"


### PR DESCRIPTION
This is essentially a duplicate of #152, but with a test added.

@rexxars, what do you think of the way I did the test? I included `remark-shortcodes` as a dev dependency, for the purpose of verifying that its attributes get passed along.

The problem is, when I run the tests, it says no assertion calls are being made. Furthermore, calling `console.log(renderHTML(component))` at the end of my test shows that it's being treated as a link reference—as though the passed-in `shortcodes` plugin is having no effect. Any chance you could help with this? Not sure where I'm going wrong.