### PR TITLE
Clarifies in the README that a children prop is accepted as an option to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ this has been planned, but if you're feeling up to the task, create an issue and
 
 ## Options
 
-* `source` - _string_ The Markdown source to parse (**required**)
+* `source` or `children` - _string_ The Markdown source to parse (**required**)
 * `className` - _string_ Class name of the container element (default: `''`).
 * `escapeHtml` - _boolean_ Setting to `false` will cause HTML to be rendered (see note above about
   broken HTML, though). Be aware that setting this to `false` might cause security issues if the


### PR DESCRIPTION
Had to dig into the source code to find whether I could pass `children` as the Markdown source, and thought it'd be nice to state that you can in the docs.