### PR TITLE
Remove todo from HTML renderer

### DIFF
--- a/src/renderers.js
+++ b/src/renderers.js
@@ -88,8 +88,7 @@ function Html(props) {
 
   const tag = props.isBlock ? 'div' : 'span'
   if (props.escapeHtml) {
-    // @todo when fiber lands, we can simply render props.value
-    return createElement(tag, null, props.value)
+    return props.value
   }
 
   const nodeProps = {dangerouslySetInnerHTML: {__html: props.value}}

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -750,13 +750,11 @@ exports[`should escape html blocks by default 1`] = `
   <p>
     This is a regular paragraph.
   </p>
-  <div>
-    &lt;table&gt;
+  &lt;table&gt;
     &lt;tr&gt;
         &lt;td&gt;Foo&lt;/td&gt;
     &lt;/tr&gt;
 &lt;/table&gt;
-  </div>
   <p>
     This is another regular paragraph.
   </p>
@@ -933,13 +931,9 @@ exports[`should handle inline html with escapeHtml option enabled 1`] = `
 <div>
   <p>
     I am having 
-    <span>
-      &lt;strong&gt;
-    </span>
+    &lt;strong&gt;
     so
-    <span>
-      &lt;/strong&gt;
-    </span>
+    &lt;/strong&gt;
      much fun
   </p>
 </div>


### PR DESCRIPTION
Fiber landed, so there's no need for the call to `createElement`.