### PR TITLE
FIX: parsing empty link references

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -54,7 +54,7 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
     props.sourcePosition = node.position
   }
 
-  const ref = node.identifier ? opts.definitions[node.identifier] || {} : null
+  const ref = (node.identifier !== null && node.identifier !== undefined) ? opts.definitions[node.identifier] || {} : null
 
   switch (node.type) {
     case 'root':

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -1183,6 +1183,8 @@ exports[`should pass on raw source position to non-tag renderers if rawSourcePos
 </div>
 `;
 
+exports[`should render empty link references 1`] = `"<p>Stuff were changed in <a href=\\"\\"></a>. Check out the changelog for reference.</p>"`;
+
 exports[`should render image references 1`] = `"<p>Checkout out this ninja: <img src=\\"/assets/ninja.png\\" alt=\\"The Waffle Ninja\\"/>. Pretty neat, eh?</p>"`;
 
 exports[`should render link references 1`] = `"<p>Stuff were changed in <a href=\\"https://github.com/rexxars/react-markdown/compare/v1.1.3...v1.1.4\\">1.1.4</a>. Check out the changelog for reference.</p>"`;

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -339,6 +339,12 @@ test('should render link references', () => {
   expect(renderHTML(<Markdown source={input} />)).toMatchSnapshot()
 })
 
+test('should render empty link references', () => {
+  const input = 'Stuff were changed in [][]. Check out the changelog for reference.';
+
+  expect(renderHTML(<Markdown source={input} />)).toMatchSnapshot()
+})
+
 test('should render image references', () => {
   const input = [
     'Checkout out this ninja: ![The Waffle Ninja][ninja]. Pretty neat, eh?',


### PR DESCRIPTION
Fix bug when in markdown template presents empty link reference `[][]`

For such values at time of mapping syntax tree to react components in this line
https://github.com/rexxars/react-markdown/blob/master/src/ast-to-react.js#L57
`node. identifier` is empty string and as result `ref` will be `null`.  As result later in line 
https://github.com/rexxars/react-markdown/blob/master/src/ast-to-react.js#L105
at time of getting `ref.href` application will throw exception.

Fixed it. Test case added.