### PR TITLE
Add more metadata props to list and listItem

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -67,10 +67,13 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
       props.start = node.start
       props.ordered = node.ordered
       props.tight = !node.loose
+      props.depth = node.depth
       break
     case 'listItem':
       props.checked = node.checked
       props.tight = !node.loose
+      props.ordered = node.ordered
+      props.index = node.index
       props.children = (props.tight ? unwrapParagraphs(node) : node.children).map((childNode, i) => {
         return astToReact(childNode, opts, {node: node, props: props}, i)
       })


### PR DESCRIPTION
Thank you for this library! I have tried to use other React libraries for rendering markdown in React *Native*, but many fell short. Thanks to *remark*, I have now found a robust way of manipulating Markdown before rendering.

This library apparently is meant only for React DOM, but I have found a way of supporting RN. Basically the biggest challenge lies with avoiding `<View>` inside `<Text>`, which is not allowed on RN for Android. On the web it's not a big deal to have, e.g., `<div>` inside `<span>`, so that's why this library works fine for the web. In particular, one of the tricky things to render are nested lists, e.g.:

```
- First
- Second
  - 2a
  - 2b
- Third
```

I made https://gitlab.com/staltz/mdast-normalize-react-native which transforms the AST so that it avoids complicated AST nodes that are hard to render with custom renderers in `react-markdown`. One of these transformations adds more metadata to `list` and `listItem`.

With this PR, custom renderers in `react-markdown` can utilize those additional props, and nested lists can then be rendered correctly. I have tested this in a real app, and I can tell it's all working great. You could say react-markdown is :+1: for React Native.

I'm not depending on this PR being merged because I published a fork:
https://www.npmjs.com/package/@staltz/react-markdown, but would appreciate if it gets merged. Thanks.