### PR TITLE
Add target attribute to links [#146]

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ this has been planned, but if you're feeling up to the task, create an issue and
   `allowedTypes` (or specified as a `disallowedType`), it won't be included. The function will
   receive three arguments argument (`node`, `index`, `parent`), where `node` contains different
   properties depending on the node type.
+* `linkTarget` - _function|string_ Sets the default target attribute for links. If a function is
+  provided, it will be called with `url`, `text`, and `title` and should return a string
+  (e.g. `_blank` for a new tab).
 * `transformLinkUri` - _function|null_ Function that gets called for each encountered link with a
   single argument - `uri`. The returned value is used in place of the original. The default link URI
   transformer acts as an XSS-filter, neutralizing things like `javascript:`, `vbscript:` and `file:`

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -91,6 +91,7 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
     case 'link':
       assignDefined(props, {
         title: node.title || undefined,
+        target: opts.linkTarget instanceof Function ? opts.linkTarget(node.url, node.children, node.title) : opts.linkTarget,
         href: opts.transformLinkUri ? opts.transformLinkUri(node.url, node.children, node.title) : node.url
       })
       break

--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -93,6 +93,7 @@ ReactMarkdown.propTypes = {
   allowedTypes: PropTypes.arrayOf(PropTypes.oneOf(allTypes)),
   disallowedTypes: PropTypes.arrayOf(PropTypes.oneOf(allTypes)),
   transformLinkUri: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+  linkTarget: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   transformImageUri: PropTypes.func,
   astPlugins: PropTypes.arrayOf(PropTypes.func),
   unwrapDisallowed: PropTypes.bool,

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -745,6 +745,21 @@ exports[`should be able to render inline html in totally unsatisfying, weird way
 </div>
 `;
 
+exports[`should call function to get target attribute for links if specified 1`] = `
+<div>
+  <p>
+    This is 
+    <a
+      href="https://espen.codes/"
+      target="_blank"
+    >
+      a link
+    </a>
+     to Espen.Codes.
+  </p>
+</div>
+`;
+
 exports[`should escape html blocks by default 1`] = `
 <div>
   <p>
@@ -1313,6 +1328,21 @@ exports[`should unwrap child nodes from disallowed nodes, if unwrapDisallowed op
      had the initial commit
     , but has had several 
     contributors
+  </p>
+</div>
+`;
+
+exports[`should use target attribute for links if specified 1`] = `
+<div>
+  <p>
+    This is 
+    <a
+      href="https://espen.codes/"
+      target="_blank"
+    >
+      a link
+    </a>
+     to Espen.Codes.
   </p>
 </div>
 `;

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -65,6 +65,19 @@ test('should handle links with custom uri transformer', () => {
   expect(component.toJSON()).toMatchSnapshot()
 })
 
+test('should use target attribute for links if specified', () => {
+  const input = 'This is [a link](https://espen.codes/) to Espen.Codes.'
+  const component = renderer.create(<Markdown linkTarget="_blank" source={input} />)
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
+test('should call function to get target attribute for links if specified', () => {
+  const input = 'This is [a link](https://espen.codes/) to Espen.Codes.'
+  const getTarget = (uri) => uri.match(/^http/) ? '_blank' : undefined;
+  const component = renderer.create(<Markdown linkTarget={getTarget} source={input} />)
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
 test('should handle images without title attribute', () => {
   const input = 'This is ![an image](/ninja.png).'
   const component = renderer.create(<Markdown source={input} />)


### PR DESCRIPTION
Addresses issue #146 by adding a `linkTarget` attribute to default the target attribute for all links.

This can also be set to a function to support the case where links to specific domains should open in new tabs but not other links.

I considered the url parsing strategy suggested in #146 but did not implement it as it's non-standard markdown. I believe a better approach would be to use a mdast plugin.