### PR TITLE
Add support for passing options to remark-parse plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ this has been planned, but if you're feeling up to the task, create an issue and
   varies based on the type of node.
   * With one exception: if the key is `text`, the value should be a function that takes the literal text and returns a new string or React element.
 * `plugins` - _array_ An array of unified/remark parser plugins. If you need to pass options to the plugin, pass an array with two elements, the first being the plugin and the second being the options - for instance: `{plugins: [[require('remark-shortcodes'), {your: 'options'}]]`. (default: `[]`)
- 
+* `remarkParseOptions` - _object_ An object containing options to pass to the `remark-parse` plugin.
 
 ## Node types
 

--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -17,6 +17,7 @@ const allTypes = Object.keys(defaultRenderers)
 
 const ReactMarkdown = function ReactMarkdown(props) {
   const src = props.source || props.children || ''
+  const remarkParseOptions = props.remarkParseOptions;
 
   if (props.allowedTypes && props.disallowedTypes) {
     throw new Error('Only one of `allowedTypes` and `disallowedTypes` should be defined')
@@ -24,7 +25,7 @@ const ReactMarkdown = function ReactMarkdown(props) {
 
   const renderers = xtend(defaultRenderers, props.renderers)
 
-  const plugins = [parse].concat(props.plugins || [])
+  const plugins = [[parse, remarkParseOptions]].concat(props.plugins || [])
   const parser = plugins.reduce(applyParserPlugin, unified())
 
   const rawAst = parser.parse(src)
@@ -78,7 +79,8 @@ ReactMarkdown.defaultProps = {
   rawSourcePos: false,
   transformLinkUri: uriTransformer,
   astPlugins: [],
-  plugins: []
+  plugins: [],
+  remarkParseOptions: {},
 }
 
 ReactMarkdown.propTypes = {
@@ -97,7 +99,8 @@ ReactMarkdown.propTypes = {
   astPlugins: PropTypes.arrayOf(PropTypes.func),
   unwrapDisallowed: PropTypes.bool,
   renderers: PropTypes.object,
-  plugins: PropTypes.array
+  plugins: PropTypes.array,
+  remarkParseOptions: PropTypes.object,
 }
 
 ReactMarkdown.types = allTypes

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -1358,3 +1358,16 @@ exports[`uses passed classname for root component 1`] = `
   </p>
 </div>
 `;
+
+exports[`should be able to override remark-parse plugin options 1`] = `
+<div>
+  <p>
+    <a
+      href="https://example.com/so much space"
+      title="Title"
+    >
+      Spaces in URLs
+    </a>
+  </p>
+</div>
+`;

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -583,3 +583,11 @@ test('should pass the key to an overriden text renderer', () => {
   renderer.create(<Markdown source={'foo'} renderers={{ text: textRenderer }} />)
 })
 
+test('should be able to override remark-parse plugin options', () => {
+  // gfm is used by default in remark-parse which will not autolink URLs
+  // containing a space unless the pedantic option is set to true.
+  const input = '[Spaces in URLs](https://example.com/so much space "Title")'
+  const component = renderer.create(<Markdown source={input} remarkParseOptions={{ pedantic: true }} />)
+
+  expect(component.toJSON()).toMatchSnapshot()
+})


### PR DESCRIPTION
Will also address https://github.com/rexxars/react-markdown/issues/129

Not sure if the test is good since it is dependent on a specific behaviour in `remark-parse`.