### PR TITLE
Add support for passing index info to renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ this has been planned, but if you're feeling up to the task, create an issue and
 * `sourcePos` - _boolean_ Setting to `true` will add `data-sourcepos` attributes to all elements,
   indicating where in the markdown source they were rendered from (default: `false`).
 * `rawSourcePos` - _boolean_ Setting to `true` will pass a `sourcePosition` property to all renderers with structured source position information (default: `false`).
+* `indexUnderParent` - _boolean_ Setting to `true` will pass `indexUnderParent` and `parentChildCount` props to all renderers (default: `false`).
 * `allowedTypes` - _array_ Defines which types of nodes should be allowed (rendered). (default: all
   types).
 * `disallowedTypes` - _array_ Defines which types of nodes should be disallowed (not rendered).

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ this has been planned, but if you're feeling up to the task, create an issue and
 * `sourcePos` - _boolean_ Setting to `true` will add `data-sourcepos` attributes to all elements,
   indicating where in the markdown source they were rendered from (default: `false`).
 * `rawSourcePos` - _boolean_ Setting to `true` will pass a `sourcePosition` property to all renderers with structured source position information (default: `false`).
-* `indexUnderParent` - _boolean_ Setting to `true` will pass `indexUnderParent` and `parentChildCount` props to all renderers (default: `false`).
+* `includeNodeIndex` - _boolean_ Setting to `true` will pass `index` and `parentChildCount` props to all renderers (default: `false`).
 * `allowedTypes` - _array_ Defines which types of nodes should be allowed (rendered). (default: all
   types).
 * `disallowedTypes` - _array_ Defines which types of nodes should be disallowed (not rendered).

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -54,9 +54,9 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
     props.sourcePosition = node.position
   }
 
-  // If `indexUnderParent` is true, pass node index info to all non-tag renderers
-  if (opts.indexUnderParent && parent.node && parent.node.children && !isTagRenderer) {
-    props.indexUnderParent = parent.node.children.indexOf(node);
+  // If `includeNodeIndex` is true, pass node index info to all non-tag renderers
+  if (opts.includeNodeIndex && parent.node && parent.node.children && !isTagRenderer) {
+    props.index = parent.node.children.indexOf(node);
     props.parentChildCount = parent.node.children.length;
   }
 

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -54,6 +54,12 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
     props.sourcePosition = node.position
   }
 
+  // If `indexUnderParent` is true, pass node index info to all non-tag renderers
+  if (opts.indexUnderParent && parent.node && parent.node.children && !isTagRenderer) {
+    props.indexUnderParent = parent.node.children.indexOf(node);
+    props.parentChildCount = parent.node.children.length;
+  }
+
   const ref = (node.identifier !== null && node.identifier !== undefined) ? opts.definitions[node.identifier] || {} : null
 
   switch (node.type) {

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -1187,37 +1187,37 @@ exports[`should pass depth, index and ordered props to list/listItem 1`] = `
 </div>
 `;
 
-exports[`should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled 1`] = `
+exports[`should pass index of a node under its parent to non-tag renderers if includeNodeIndex option is enabled 1`] = `
 Object {
   "children": Array [
     "Foo",
   ],
-  "indexUnderParent": 0,
+  "index": 0,
   "parentChildCount": 3,
 }
 `;
 
-exports[`should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled 2`] = `
+exports[`should pass index of a node under its parent to non-tag renderers if includeNodeIndex option is enabled 2`] = `
 Object {
   "children": Array [
     "Bar",
   ],
-  "indexUnderParent": 1,
+  "index": 1,
   "parentChildCount": 3,
 }
 `;
 
-exports[`should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled 3`] = `
+exports[`should pass index of a node under its parent to non-tag renderers if includeNodeIndex option is enabled 3`] = `
 Object {
   "children": Array [
     "Baz",
   ],
-  "indexUnderParent": 2,
+  "index": 2,
   "parentChildCount": 3,
 }
 `;
 
-exports[`should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled 4`] = `
+exports[`should pass index of a node under its parent to non-tag renderers if includeNodeIndex option is enabled 4`] = `
 <div>
   <p>
     Foo

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -1187,6 +1187,50 @@ exports[`should pass depth, index and ordered props to list/listItem 1`] = `
 </div>
 `;
 
+exports[`should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled 1`] = `
+Object {
+  "children": Array [
+    "Foo",
+  ],
+  "indexUnderParent": 0,
+  "parentChildCount": 3,
+}
+`;
+
+exports[`should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled 2`] = `
+Object {
+  "children": Array [
+    "Bar",
+  ],
+  "indexUnderParent": 1,
+  "parentChildCount": 3,
+}
+`;
+
+exports[`should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled 3`] = `
+Object {
+  "children": Array [
+    "Baz",
+  ],
+  "indexUnderParent": 2,
+  "parentChildCount": 3,
+}
+`;
+
+exports[`should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled 4`] = `
+<div>
+  <p>
+    Foo
+  </p>
+  <p>
+    Bar
+  </p>
+  <p>
+    Baz
+  </p>
+</div>
+`;
+
 exports[`should pass on raw source position to non-tag renderers if rawSourcePos option is enabled 1`] = `
 Position {
   "end": Object {

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -596,3 +596,13 @@ test('should pass the key to an overriden text renderer', () => {
   renderer.create(<Markdown source={'foo'} renderers={{ text: textRenderer }} />)
 })
 
+test('should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled', () => {
+  const input = 'Foo\n\nBar\n\nBaz'
+  const paragraph = props => {
+    expect(props).toMatchSnapshot()
+    return <p>{props.children}</p>
+  };
+
+  const component = renderer.create(<Markdown renderers={{ paragraph }} source={input} indexUnderParent />)
+  expect(component.toJSON()).toMatchSnapshot()
+})

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -596,13 +596,13 @@ test('should pass the key to an overriden text renderer', () => {
   renderer.create(<Markdown source={'foo'} renderers={{ text: textRenderer }} />)
 })
 
-test('should pass index of a node under its parent to non-tag renderers if indexUnderParent option is enabled', () => {
+test('should pass index of a node under its parent to non-tag renderers if includeNodeIndex option is enabled', () => {
   const input = 'Foo\n\nBar\n\nBaz'
   const paragraph = props => {
     expect(props).toMatchSnapshot()
     return <p>{props.children}</p>
   };
 
-  const component = renderer.create(<Markdown renderers={{ paragraph }} source={input} indexUnderParent />)
+  const component = renderer.create(<Markdown renderers={{ paragraph }} source={input} includeNodeIndex />)
   expect(component.toJSON()).toMatchSnapshot()
 })


### PR DESCRIPTION
When `indexUnderParent` prop is `true`, pass `indexUnderParent` and `parentChildCount` props to non-tag renderers.

Resolves #213