### PR TITLE
Add ignoreTokens prop to allow skipping parse of specific Markdown tokens

### DIFF
--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -1151,6 +1151,25 @@ exports[`should handle tight, unordered lists with sublists 1`] = `
 </div>
 `;
 
+exports[`should not process tokens that are defined to ignore 1`] = `
+<div>
+  <p>
+    # Header
+  </p>
+  <p>
+    Paragraph
+## New header
+1. List item
+2. List item 2
+  </p>
+  <p>
+    \`code\`
+__italic__
+**bold**
+  </p>
+</div>
+`;
+
 exports[`should only use first language definition on code blocks 1`] = `
 <div>
   <pre>

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -315,6 +315,41 @@ test('should pass on raw source position to non-tag renderers if rawSourcePos op
   expect(component.toJSON()).toMatchSnapshot()
 })
 
+test('should not process tokens that are defined to ignore', () => {
+  const input = '# Header\n\nParagraph\n## New header\n1. List item\n2. List item 2\n\n`code`\n__italic__\n**bold**'
+  const ignore = [
+    // blockMethods
+    // 'newline',
+    'indentedCode',
+    'fencedCode',
+    'blockquote',
+    'atxHeading',
+    'thematicBreak',
+    // 'list',
+    'setextHeading',
+    // 'html',
+    'footnote',
+    'definition',
+    'table',
+    // 'paragraph',
+    // inlineMethods
+    // 'escape',
+    'autoLink',
+    'url',
+    // 'html',
+    'link',
+    'reference',
+    'strong',
+    'emphasis',
+    'deletion',
+    'code',
+    'break',
+    // 'text'
+  ]
+  const component = renderer.create(<Markdown source={input} ignoreTokens={ignore} />)
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
 test('should skip nodes that are not defined as allowed', () => {
   const input = '# Header\n\nParagraph\n## New header\n1. List item\n2. List item 2'
   const allowed = ['paragraph', 'list', 'listItem']


### PR DESCRIPTION
Here's a proof of concept for the ability to disable parsing of specific tokens. I'm not excited about the level of messing with the parser prototype. And it does seem that some tokenizers just can't be disabled without throwing errors (eg a `list` tokenizer reference is hardcoded, so it can't be removed without breaking other things). In the test, I included the full list of tokenizers, and commented out the ones that don't seem to be cleanly removable. 

I'm conflicted about this, because the ability to disable parsing of some tokens is a requirement for us, and this seems like the best way to do it. On the other hand, `remark-parse` clearly wasn't designed for disabling these parsers, and the [documented method](https://github.com/remarkjs/remark/tree/master/packages/remark-parse#turning-off-a-tokenizer) for doing so is a brittle hack.

If it makes sense to move forward, there are some more tests, error handling & refactoring I plan to do, but just want to get some general feedback before spending more time on it.

Eager to hear others' thoughts on this approach.