### PR TITLE
Add note about only parsing plugins working

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ this is a Good Thing™.
 * `renderers` - _object_ An object where the keys represent the node type and the value is a React
   component. The object is merged with the default renderers. The props passed to the component
   varies based on the type of node.
-* `plugins` - _array_ An array of unified/remark parser plugins. If you need to pass options to the plugin, pass an array with two elements, the first being the plugin and the second being the options - for instance: `{plugins: [[require('remark-shortcodes'), {your: 'options'}]]`. (default: `[]`)
+* `plugins` - _array_ An array of unified/remark parser plugins. If you need to pass options to the plugin, pass an array with two elements, the first being the plugin and the second being the options - for instance: `{plugins: [[require('remark-shortcodes'), {your: 'options'}]]`. (default: `[]`) Note that [not all plugins can be used](https://github.com/rexxars/react-markdown/issues/188#issuecomment-404710893).
 
 ## Parsing HTML
 


### PR DESCRIPTION
I tried using a plugin with react-markdown, and only after finding https://github.com/rexxars/react-markdown/issues/188#issuecomment-404710893 did I learn that it was not going to work as the plugin I was hoping to use was using `transform`. Thus, it might be a good idea to be more upfront about it, to prevent unnecessary work.

(Of course this note can be removed again if someone does find a solution to support non-parsing plugins.)