### PR TITLE
Allow arbitrary renderer types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare namespace ReactMarkdown {
     readonly transformLinkUri?: (uri: string, children?: ReactNode, title?: string) => string
     readonly transformImageUri?: (uri: string, children?: ReactNode, title?: string, alt?: string) => string
     readonly unwrapDisallowed?: boolean
-    readonly renderers?: {[nodeType in NodeType]?: ReactType}
+    readonly renderers?: {[nodeType: string]: ReactType}
     readonly astPlugins?: MdastPlugin[]
     readonly plugins?: any[] | (() => void)
   }


### PR DESCRIPTION
Since [renderers for arbitrary node types are allowed](https://github.com/rexxars/react-markdown/issues/162), the typings should reflect this.