### PR TITLE
Upgrade remark-parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8049,9 +8049,9 @@
       "dev": true
     },
     "remark-parse": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-      "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
       "requires": {
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "html-to-react": "^1.3.3",
     "mdast-add-list-metadata": "1.0.1",
     "prop-types": "^15.6.1",
-    "remark-parse": "^5.0.0",
+    "remark-parse": "^6.0.0",
     "unified": "^6.1.5",
     "unist-util-visit": "^1.3.0",
     "xtend": "^4.0.1"

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -181,14 +181,10 @@ Array [
   </p>,
   <ul>
     <li>
-      <p>
-        foo
-      </p>
+      foo
     </li>
     <li>
-      <p>
-        bar
-      </p>
+      bar
     </li>
   </ul>,
   <h2>
@@ -654,14 +650,10 @@ Array [
   </p>,
   <ul>
     <li>
-      <p>
-        foo
-      </p>
+      foo
     </li>
     <li>
-      <p>
-        bar
-      </p>
+      bar
     </li>
   </ul>,
   <h2>
@@ -1617,14 +1609,10 @@ exports[`should handle links without title attribute 1`] = `
 exports[`should handle loose, unordered lists 1`] = `
 <ul>
   <li>
-    <p>
-      foo
-    </p>
+    foo
   </li>
   <li>
-    <p>
-      bar
-    </p>
+    bar
   </li>
 </ul>
 `;
@@ -1632,9 +1620,7 @@ exports[`should handle loose, unordered lists 1`] = `
 exports[`should handle loose, unordered lists with sublists 1`] = `
 <ul>
   <li>
-    <p>
-      foo
-    </p>
+    foo
     <ul>
       <li>
         bar


### PR DESCRIPTION
Unsure if this will break things on the `react-markdown` side. I wanted to see about upgrading remark (xref: https://github.com/nteract/nteract/pull/3483).