### PR TITLE
Fix HTML parsing of multiple void elements

### DIFF
--- a/src/plugins/html-parser.js
+++ b/src/plugins/html-parser.js
@@ -63,7 +63,7 @@ function parseHtml(config, tree, props) {
       }
 
       const current = parseNode(node, config)
-      if (!current) {
+      if (!current || current.type === type) {
         return true
       }
 

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -1307,6 +1307,20 @@ exports[`should be able to render inline html with self-closing tags with attrib
 </p>
 `;
 
+exports[`should be able to render multiple inline html elements with self-closing tags with attributes properly with HTML parser plugin 1`] = `
+<p>
+  I am having 
+  <wbr
+    className="foo"
+  />
+   so much 
+  <wbr
+    className="bar"
+  />
+   fun
+</p>
+`;
+
 exports[`should call function to get target attribute for links if specified 1`] = `
 <p>
   This is 

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -293,6 +293,14 @@ test('should be able to render inline html with self-closing tags with attribute
   expect(component.toJSON()).toMatchSnapshot()
 })
 
+test('should be able to render multiple inline html elements with self-closing tags with attributes properly with HTML parser plugin', () => {
+  const input = 'I am having <wbr class="foo"/> so much <wbr class="bar"/> fun'
+  const component = renderer.create(
+    <Markdown source={input} escapeHtml={false} astPlugins={[htmlParser()]} />
+  )
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
 test('should handle invalid HTML with HTML parser plugin', () => {
   const input = 'I am having <div> so much</em> fun'
   const component = renderer.create(


### PR DESCRIPTION
From https://github.com/rexxars/react-markdown/issues/270 this fixes

```
TypeError: undefined is not an object (evaluating fromNode.node.position.start)
```
