### PR TITLE
Fix matching of replaced non-void elements in HTML parser plugin

### DIFF
--- a/src/plugins/html-parser.js
+++ b/src/plugins/html-parser.js
@@ -11,6 +11,7 @@ const symbols = require('../symbols')
 
 const type = 'parsedHtml'
 const selfClosingRe = /^<(area|base|br|col|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)\s*\/?>$/i
+const startTagRe = /^<([a-z]+)\b/i
 const closingTagRe = /^<\/([a-z]+)\s*>$/
 
 const parser = new HtmlToReact.Parser()
@@ -143,7 +144,9 @@ function parseNode(node, config) {
     }
   }
 
-  return {tag: el.type, opening: true, node, element: el}
+  const startTagMatch = node.value.trim().match(startTagRe)
+  const tag = startTagMatch ? startTagMatch[1] : el.type
+  return {tag, opening: true, node, element: el}
 }
 
 function getSelfClosingTagName(node) {

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -1321,6 +1321,16 @@ exports[`should be able to render multiple inline html elements with self-closin
 </p>
 `;
 
+exports[`should be able to render replaced non-void html elements with HTML parser plugin 1`] = `
+<p>
+  I am having 
+  <kbd>
+    so much
+  </kbd>
+   fun
+</p>
+`;
+
 exports[`should call function to get target attribute for links if specified 1`] = `
 <p>
   This is 

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -312,6 +312,24 @@ test('should be able to render multiple inline html elements with self-closing t
   expect(component.toJSON()).toMatchSnapshot()
 })
 
+test('should be able to render replaced non-void html elements with HTML parser plugin', () => {
+  const input = 'I am having <code>so much</code> fun'
+  const config = {
+    isValidNode: () => true,
+    processingInstructions: [
+      {
+        shouldProcessNode: ({ name }) => name === 'code',
+        // eslint-disable-next-line react/display-name
+        processNode: (node, children) => <kbd>{children}</kbd>
+      }
+    ]
+  }
+  const component = renderer.create(
+    <Markdown source={input} escapeHtml={false} astPlugins={[htmlParser(config)]} />
+  )
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
 test('should handle invalid HTML with HTML parser plugin', () => {
   const input = 'I am having <div> so much</em> fun'
   const component = renderer.create(


### PR DESCRIPTION
In `parseNode()` from `html-parser.js` we first match against `closingTagRe` to push onto `open` to indicate we're in a non-void element.

However, if on the matching opening tag you return an element — from `parser.parseWithInstructions()` — with a different tag as what was matched by `closingTagRe`, or a custom React component (where `type` is no longer a string), you can't close off the matched non-void element.