### PR TITLE
putting [] [] in the source breaks

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -63,7 +63,7 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
   const ref =
     node.identifier !== null && node.identifier !== undefined
       ? opts.definitions[node.identifier] || {}
-      : null
+      : {}
 
   switch (node.type) {
     case 'root':


### PR DESCRIPTION
Putting [] [] in the source breaks, because ref is null then we dont null check ref.href below.
