### PR TITLE
Fix for remark-parse/types has no exported member RemarkParserOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@
 // - Ted Piotrowski <https://github.com/ted-piotrowski>
 
 import {Component, ReactElement, ReactNode, ReactType} from 'react'
-import {RemarkParserOptions} from 'remark-parse'
+import {RemarkParseOptions} from 'remark-parse'
 
 declare class ReactMarkdown extends Component<ReactMarkdown.ReactMarkdownProps, {}> {}
 
@@ -84,7 +84,7 @@ declare namespace ReactMarkdown {
     readonly renderers?: {[nodeType: string]: ReactType}
     readonly astPlugins?: MdastPlugin[]
     readonly plugins?: any[] | (() => void)
-    readonly parserOptions?: Partial<RemarkParserOptions>
+    readonly parserOptions?: Partial<RemarkParseOptions>
   }
 
   interface RenderProps extends ReactMarkdownProps {


### PR DESCRIPTION
WIth https://github.com/rexxars/react-markdown/commit/fe0b57a8e8e7256446419e2d49064a78c6d19479 commit, there was introduced `parserOptions` property with `RemarkParserOptions` type.

There is typo in the interface name - should be: `RemarkParseOptions`